### PR TITLE
metrics:  add smart-node-metrics exporter

### DIFF
--- a/tasks/smart-node.yml
+++ b/tasks/smart-node.yml
@@ -26,3 +26,13 @@
           - name: '{{ rocketpool_node_service_name }}-health'
             type: 'script'
             script: '/usr/bin/systemctl is-active {{ rocketpool_node_service_name }}'
+
+      - id:   '{{ rocketpool_node_service_name }}-metrics'
+        name: '{{ rocketpool_node_service_name }}-metrics'
+        tags: ['rocketpool', 'service', 'metrics']
+        port: '{{ rocketpool_metrics_port }}'
+        address: '{{ ansible_local.wireguard.address }}'
+        checks:
+          - name: '{{ rocketpool_node_service_name }}-metrics-health'
+            type: 'http'
+            http: 'http://localhost:{{ rocketpool_metrics_port }}/'


### PR DESCRIPTION
- adding `rocketpool-smart-node` metrics exporter

`ODao metrics` enabled in here: 
- https://github.com/status-im/infra-role-rocketpool/pull/7

Linked to: 
- https://github.com/status-im/infra-hq/pull/164
- https://github.com/status-im/infra-rocketpool/issues/11