### PR TITLE
watchtower: add --metricsPort flag to service

### DIFF
--- a/templates/rocketpool-watchtower.service.j2
+++ b/templates/rocketpool-watchtower.service.j2
@@ -9,6 +9,7 @@ Restart=always
 RestartSec=5
 ExecStart=/usr/local/bin/rocketpool-daemon \
   --settings={{ rocketpool_service_path }}/user-settings.yml \
+  --metricsPort={{ rocketpool_watchtower_metrics_port }} \
   watchtower
 
 [Install]


### PR DESCRIPTION
Workaround for rocketpool issue https://github.com/rocket-pool/smartnode/issues/689 where `watchtowerMetricsPort` in `user-settings.yml` is ignored.

Using CLI flag to bind metrics server to specific port instead of default to avoid port conflict with `Rocket Pool` metrics server.